### PR TITLE
Add Linux support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,11 +11,18 @@ on:
 
 jobs:
   build:
-
-    runs-on: macos-latest
+    name: Build and test on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
+    - uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: "6.0"
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,18 +11,30 @@ on:
 
 jobs:
   build:
-    name: Build and test on ${{ matrix.os }}
+    name: Build and test on ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        include:
+          - name: Ubuntu
+            os: ubuntu-latest
+            swift-version: "6.0"
+          - name: macOS
+            os: macos-latest
+            swift-version: ""
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
     - uses: swift-actions/setup-swift@v2
+      if: matrix.swift-version != ''
       with:
-        swift-version: "6.0"
+        swift-version: ${{ matrix.swift-version }}
+    - name: Show toolchain
+      run: swift --version
+    - name: Show Xcode version
+      if: runner.os == 'macOS'
+      run: xcodebuild -version
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlitsGeohash
 
-`FlitsGeohash` is a Swift package for working with geohashes on Apple platforms. It wraps a small C implementation with a Swift-friendly API for encoding coordinates, finding adjacent cells, collecting neighbors, and generating the geohashes that cover a region.
+`FlitsGeohash` is a Swift package for working with geohashes on Apple platforms and Linux. It wraps a small C implementation with a Swift-friendly API for encoding coordinates, finding adjacent cells, collecting neighbors, and generating the geohashes that cover a region.
 
 ## Features
 
@@ -9,12 +9,15 @@
 - Fetch all 8 neighboring geohashes
 - Generate the geohashes that cover a map region
 - Use strongly typed fixed-length geohashes for common lengths
+- Use the same coordinate API on Linux without depending on `CoreLocation`
 
 ## Requirements
 
 - Swift 6.0+
-- `CoreLocation`
 - Apple platforms where `CoreLocation` is available
+- Linux
+
+When `CoreLocation` is unavailable, `FlitsGeohash` provides compatible `CLLocationCoordinate2D`, `CLLocationDegrees`, and `CLLocationCoordinate2DIsValid` definitions so the public API stays the same across platforms.
 
 ## Installation
 
@@ -44,7 +47,9 @@ targets: [
 ### Encode a coordinate
 
 ```swift
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 import FlitsGeohash
 
 let coordinate = CLLocationCoordinate2D(
@@ -60,6 +65,8 @@ let shortHash = coordinate.geohash(length: 5)
 ```
 
 The string-based API accepts geohash lengths from `1...22`.
+
+On Linux, the snippet above works unchanged. `FlitsGeohash` exposes a compatible coordinate type when `CoreLocation` is not available.
 
 ### Adjacent cells and neighbors
 
@@ -120,7 +127,7 @@ let regionHashes = Geohash3.hashesForRegion(
 swift test
 ```
 
-The test suite includes correctness checks and performance-oriented coverage for encoding, adjacency, neighbors, and region generation.
+The test suite includes correctness checks and performance-oriented coverage for encoding, adjacency, neighbors, and region generation, and CI runs on both macOS and Ubuntu.
 
 ## Contributing
 

--- a/Sources/FlitsGeohashSwift/CLLocationCoordinate2D+Geohash.swift
+++ b/Sources/FlitsGeohashSwift/CLLocationCoordinate2D+Geohash.swift
@@ -5,7 +5,9 @@
 //  Created by Maarten Zonneveld on 08/05/2024.
 //
 
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 
 public extension CLLocationCoordinate2D {
     

--- a/Sources/FlitsGeohashSwift/CoordinateCompatibility.swift
+++ b/Sources/FlitsGeohashSwift/CoordinateCompatibility.swift
@@ -12,10 +12,10 @@ import Foundation
 
 public typealias CLLocationDegrees = Double
 
-public struct CLLocationCoordinate2D: Sendable, Hashable {
+public struct CLLocationCoordinate2D: Sendable {
     public var latitude: CLLocationDegrees
     public var longitude: CLLocationDegrees
-
+    
     public init(latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
         self.latitude = latitude
         self.longitude = longitude

--- a/Sources/FlitsGeohashSwift/CoordinateCompatibility.swift
+++ b/Sources/FlitsGeohashSwift/CoordinateCompatibility.swift
@@ -1,0 +1,29 @@
+//
+//  CoordinateCompatibility.swift
+//
+//
+//  Created by Maarten Zonneveld on 09/03/2026.
+//
+
+#if canImport(CoreLocation)
+import CoreLocation
+#else
+import Foundation
+
+public typealias CLLocationDegrees = Double
+
+public struct CLLocationCoordinate2D: Sendable, Hashable {
+    public var latitude: CLLocationDegrees
+    public var longitude: CLLocationDegrees
+
+    public init(latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+@inline(__always)
+public func CLLocationCoordinate2DIsValid(_ coordinate: CLLocationCoordinate2D) -> Bool {
+    (-90...90).contains(coordinate.latitude) && (-180...180).contains(coordinate.longitude)
+}
+#endif

--- a/Sources/FlitsGeohashSwift/GeoHash.swift
+++ b/Sources/FlitsGeohashSwift/GeoHash.swift
@@ -58,34 +58,35 @@ public enum Geohash {
     }
 
     public static func adjacent(hash: String, direction: Direction) -> String {
-        guard let pointer = GEOHASH_get_adjacent(
-            hash.cString(using: .ascii),
-            direction.cValue
-        ) else {
-            fatalError()
+        hash.withCString { hashCString in
+            guard let pointer = GEOHASH_get_adjacent(hashCString, direction.cValue) else {
+                fatalError()
+            }
+            let adjacent = string(from: pointer)
+            free(pointer)
+            return adjacent
         }
-        let adjacent = string(from: pointer)
-        free(pointer)
-        return adjacent
     }
 
     public static func neighbors(hash: String) -> Neighbors {
-        let pointer = GEOHASH_get_neighbors(hash.cString(using: .ascii))
-        guard let cNeighbors = pointer?.pointee else {
-            fatalError()
+        hash.withCString { hashCString in
+            guard let pointer = GEOHASH_get_neighbors(hashCString) else {
+                fatalError()
+            }
+            let cNeighbors = pointer.pointee
+            let neighbors = Neighbors(
+                north: string(from: cNeighbors.north),
+                south: string(from: cNeighbors.south),
+                west: string(from: cNeighbors.west),
+                east: string(from: cNeighbors.east),
+                northWest: string(from: cNeighbors.north_west),
+                northEast: string(from: cNeighbors.north_east),
+                southWest: string(from: cNeighbors.south_west),
+                southEast: string(from: cNeighbors.south_east)
+            )
+            GEOHASH_free_neighbors(pointer)
+            return neighbors
         }
-        let neighbors = Neighbors(
-            north: string(from: cNeighbors.north),
-            south: string(from: cNeighbors.south),
-            west: string(from: cNeighbors.west),
-            east: string(from: cNeighbors.east),
-            northWest: string(from: cNeighbors.north_west),
-            northEast: string(from: cNeighbors.north_east),
-            southWest: string(from: cNeighbors.south_west),
-            southEast: string(from: cNeighbors.south_east)
-        )
-        GEOHASH_free_neighbors(pointer)
-        return neighbors
     }
     
     public static func hashesForRegion(

--- a/Sources/FlitsGeohashSwift/GeoHash.swift
+++ b/Sources/FlitsGeohashSwift/GeoHash.swift
@@ -5,7 +5,14 @@
 //  Created by Maarten Zonneveld on 07/05/2024.
 //
 
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 public enum Geohash {
 
@@ -40,12 +47,8 @@ public enum Geohash {
     }
 
     public static func hash(_ coordinate: CLLocationCoordinate2D, length: UInt32) -> String {
-        if !CLLocationCoordinate2DIsValid(coordinate) {
-            assertionFailure("coordinate is invalid")
-        }
-        if length < 1, length > 22 {
-            assertionFailure("length must be greater than 0 and less than 23")
-        }
+        precondition(CLLocationCoordinate2DIsValid(coordinate), "coordinate is invalid")
+        precondition(length > 0 && length < 23, "length must be greater than 0 and less than 23")
         guard let pointer = GEOHASH_encode(coordinate.latitude, coordinate.longitude, length) else {
             fatalError()
         }

--- a/Sources/FlitsGeohashSwift/LengthedGeohash.swift
+++ b/Sources/FlitsGeohashSwift/LengthedGeohash.swift
@@ -5,7 +5,9 @@
 //  Created by Maarten Zonneveld on 21/05/2024.
 //
 
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 
 public protocol GeohashLengthed {
     static var length: UInt32 { get }

--- a/Tests/FlitsGeohashSwiftTests/LengthTests.swift
+++ b/Tests/FlitsGeohashSwiftTests/LengthTests.swift
@@ -1,6 +1,8 @@
 
 import XCTest
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 import FlitsGeohash
 
 final class GeohashTests: XCTestCase {

--- a/Tests/FlitsGeohashSwiftTests/PerformanceTests.swift
+++ b/Tests/FlitsGeohashSwiftTests/PerformanceTests.swift
@@ -6,7 +6,9 @@
 //
 
 import XCTest
+#if canImport(CoreLocation)
 import CoreLocation
+#endif
 import FlitsGeohash
 
 final class PerformanceTests: XCTestCase {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands the package to Linux by introducing CoreLocation compatibility shims and changing C-interop string/memory handling in core geohash functions; cross-platform behavior and failure modes should be revalidated.
> 
> **Overview**
> Adds **Linux support** while keeping the public coordinate-based API consistent by introducing `CoordinateCompatibility.swift` (fallback `CLLocationCoordinate2D`/`CLLocationDegrees`/`CLLocationCoordinate2DIsValid` when `CoreLocation` is unavailable) and gating `CoreLocation` imports across sources/tests.
> 
> Updates `Geohash` to be cross-platform (`Glibc` vs `Darwin`), tightens argument validation with `precondition`, and switches C string bridging in `adjacent`/`neighbors` to `withCString` for safer interop and correct freeing.
> 
> Extends CI to run build/tests on both macOS and Ubuntu (Swift 6 on Ubuntu) and updates the README to document Linux usage and conditional `CoreLocation` imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33e85b561fc2844319073361381d99604749964f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->