### PR TITLE
Handle world boundaries

### DIFF
--- a/Sources/FlitsGeohashC/flitsgeohash.c
+++ b/Sources/FlitsGeohashC/flitsgeohash.c
@@ -109,6 +109,9 @@ GEOHASH_get_neighbors(const char* hash)
 void
 GEOHASH_free_neighbors(GEOHASH_neighbors *neighbors)
 {
+    if (neighbors == NULL)
+        return;
+
     free(neighbors->north);
     free(neighbors->east);
     free(neighbors->west);
@@ -127,7 +130,18 @@ GEOHASH_get_adjacent(const char* hash, GEOHASH_direction dir)
     const char *border_table, *neighbor_table;
     char *base, *refined_base, *ptr, last;
 
+    if (hash == NULL)
+        return NULL;
+
     len  = strlen(hash);
+    if (len == 0) {
+        base = (char *)malloc(sizeof(char));
+        if (base == NULL)
+            return NULL;
+        base[0] = '\0';
+        return base;
+    }
+
     last = tolower(hash[len - 1]);
     idx  = dir * 2 + (len % 2);
 

--- a/Tests/FlitsGeohashSwiftTests/CorrectnessTests.swift
+++ b/Tests/FlitsGeohashSwiftTests/CorrectnessTests.swift
@@ -29,6 +29,21 @@ final class CorrectnessTests: XCTestCase {
         XCTAssertEqual(Geohash.adjacent(hash: Fixture.hash11, direction: .west), Fixture.west)
     }
 
+    func testGeohashAdjacentHandlesWorldBoundaryHashes() {
+        let cases: [(hash: String, direction: Geohash.Direction, expected: String)] = [
+            ("bpbpbp", .north, "000000"),
+            ("zzzzzz", .east, "bpbpbp"),
+            ("000000", .south, "bpbpbp"),
+            ("000000", .west, "pbpbpb")
+        ]
+
+        for testCase in cases {
+            let adjacent = Geohash.adjacent(hash: testCase.hash, direction: testCase.direction)
+
+            XCTAssertEqual(adjacent, testCase.expected)
+        }
+    }
+
     func testGeohashNeighborsAndNeighborSets() {
         let neighbors = Geohash.neighbors(hash: Fixture.hash11)
 
@@ -45,6 +60,24 @@ final class CorrectnessTests: XCTestCase {
             neighbors.allNeighbors(and: Fixture.hash11),
             Fixture.stringNeighbors.union([Fixture.hash11])
         )
+    }
+
+    func testGeohashNeighborsHandlesOriginAdjacentGeneratedHashes() {
+        let originAdjacentHashes = Geohash.hashesForRegion(
+            centerCoordinate: .init(latitude: 0, longitude: 0),
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+            length: 6
+        )
+
+        XCTAssertEqual(Set(originAdjacentHashes), Set(["7zzzzz", "ebpbpb", "kpbpbp", "s00000"]))
+
+        for hash in originAdjacentHashes {
+            let neighbors = Geohash.neighbors(hash: hash)
+
+            XCTAssertTrue(neighbors.allNeighbors.allSatisfy { $0.count == hash.count })
+            XCTAssertTrue(neighbors.allNeighbors.allSatisfy { !$0.isEmpty })
+        }
     }
 
     func testGeohashHashesForRegion() {


### PR DESCRIPTION
Fixes a crash in GEOHASH_get_adjacent when resolving adjacent geohashes on world boundaries.

Previously, recursive border handling could reduce the base hash to an empty string and then read hash[len - 1], causing undefined behavior and possible stack overflow/crash. The C implementation now treats the empty prefix as the recursion base case, allowing the existing geohash neighbor tables to wrap deterministically across boundaries.